### PR TITLE
build(deps): bump martian to 1.2.4 (support converting math and tables from MD --> Notion)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "notionater",
-  "version": "1.0.8",
+  "version": "1.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "notionater",
-      "version": "1.0.8",
+      "version": "1.0.11",
       "license": "MIT",
       "dependencies": {
         "@notionhq/client": "^0.4.4",
-        "@tryfabric/martian": "github:cliftonc/martian#better-images",
+        "@tryfabric/martian": "github:tryfabric/martian",
         "await-spawn": "^4.0.2",
         "cli-progress": "^3.9.1",
         "commander": "^8.3.0",
@@ -222,17 +222,31 @@
       }
     },
     "node_modules/@tryfabric/martian": {
-      "version": "1.1.0",
-      "resolved": "git+ssh://git@github.com/cliftonc/martian.git#9dd76990cbd40a1ae23291cdb08c3b9f5b64a279",
+      "version": "1.2.4",
+      "resolved": "git+ssh://git@github.com/tryfabric/martian.git#dfae74cf1162ff9aeb812d568bcdb62e65ad597c",
       "license": "ISC",
       "dependencies": {
-        "@notionhq/client": "^0.4.5",
+        "@notionhq/client": "^1.0.4",
         "remark-gfm": "^1.0.0",
+        "remark-math": "^4.0.0",
         "remark-parse": "^9.0.0",
         "unified": "^9.2.1"
       },
       "engines": {
         "node": ">=15"
+      }
+    },
+    "node_modules/@tryfabric/martian/node_modules/@notionhq/client": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-1.0.4.tgz",
+      "integrity": "sha512-m7zZ5l3RUktayf1lRBV1XMb8HSKsmWTv/LZPqP7UGC1NMzOlc+bbTOPNQ4CP/c1P4cP61VWLb/zBq7a3c0nMaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node-fetch": "^2.5.10",
+        "node-fetch": "^2.6.1"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@types/json5": {
@@ -1843,6 +1857,24 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/katex": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.12.0.tgz",
+      "integrity": "sha512-y+8btoc/CK70XqcHqjxiGWBOeIL8upbS0peTPXTvgrh21n1RiWWcIpSWM+4uXq+IAgNh9YYQWdc7LVDPDAEEAg==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^2.19.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -2019,6 +2051,21 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-math": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-0.1.2.tgz",
+      "integrity": "sha512-fogAitds+wH+QRas78Yr1TwmQGN4cW/G2WRw5ePuNoJbBSPJCxIOCE8MTzHgWHVSpgkRaPQTgfzXRE1CrwWSlg==",
+      "license": "MIT",
+      "dependencies": {
+        "longest-streak": "^2.0.0",
+        "mdast-util-to-markdown": "^0.6.0",
+        "repeat-string": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-to-markdown": {
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz",
@@ -2139,6 +2186,20 @@
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-0.3.3.tgz",
       "integrity": "sha512-0zvM5iSLKrc/NQl84pZSjGo66aTGd57C1idmlWmE87lkMcXrTxg1uXa/nXomxJytoje9trP0NDLvw4bZ/Z/XCQ==",
       "dependencies": {
+        "micromark": "~2.11.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-0.1.2.tgz",
+      "integrity": "sha512-ZJXsT2eVPM8VTmcw0CPSDeyonOn9SziGK3Z+nkf9Vb6xMPeU+4JMEnO6vzDL10562Favw8Vste74f54rxJ/i6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "katex": "^0.12.0",
         "micromark": "~2.11.0"
       },
       "funding": {
@@ -2501,6 +2562,20 @@
       "dependencies": {
         "mdast-util-gfm": "^0.1.0",
         "micromark-extension-gfm": "^0.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-math": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-4.0.0.tgz",
+      "integrity": "sha512-lH7SoQenXtQrvL0bm+mjZbvOk//YWNuyR+MxV18Qyv8rgFmMEGNuB0TSCQDkoDaiJ40FCnG8lxErc/zhcedYbw==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-math": "^0.1.0",
+        "micromark-extension-math": "^0.1.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3243,13 +3318,25 @@
       }
     },
     "@tryfabric/martian": {
-      "version": "git+ssh://git@github.com/cliftonc/martian.git#9dd76990cbd40a1ae23291cdb08c3b9f5b64a279",
-      "from": "@tryfabric/martian@github:cliftonc/martian#better-images",
+      "version": "git+ssh://git@github.com/tryfabric/martian.git#dfae74cf1162ff9aeb812d568bcdb62e65ad597c",
+      "from": "@tryfabric/martian@github:tryfabric/martian",
       "requires": {
-        "@notionhq/client": "^0.4.5",
+        "@notionhq/client": "^1.0.4",
         "remark-gfm": "^1.0.0",
+        "remark-math": "^4.0.0",
         "remark-parse": "^9.0.0",
         "unified": "^9.2.1"
+      },
+      "dependencies": {
+        "@notionhq/client": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-1.0.4.tgz",
+          "integrity": "sha512-m7zZ5l3RUktayf1lRBV1XMb8HSKsmWTv/LZPqP7UGC1NMzOlc+bbTOPNQ4CP/c1P4cP61VWLb/zBq7a3c0nMaw==",
+          "requires": {
+            "@types/node-fetch": "^2.5.10",
+            "node-fetch": "^2.6.1"
+          }
+        }
       }
     },
     "@types/json5": {
@@ -4386,6 +4473,21 @@
         "minimist": "^1.2.0"
       }
     },
+    "katex": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.12.0.tgz",
+      "integrity": "sha512-y+8btoc/CK70XqcHqjxiGWBOeIL8upbS0peTPXTvgrh21n1RiWWcIpSWM+4uXq+IAgNh9YYQWdc7LVDPDAEEAg==",
+      "requires": {
+        "commander": "^2.19.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        }
+      }
+    },
     "kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -4514,6 +4616,16 @@
         "mdast-util-to-markdown": "~0.6.0"
       }
     },
+    "mdast-util-math": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-0.1.2.tgz",
+      "integrity": "sha512-fogAitds+wH+QRas78Yr1TwmQGN4cW/G2WRw5ePuNoJbBSPJCxIOCE8MTzHgWHVSpgkRaPQTgfzXRE1CrwWSlg==",
+      "requires": {
+        "longest-streak": "^2.0.0",
+        "mdast-util-to-markdown": "^0.6.0",
+        "repeat-string": "^1.0.0"
+      }
+    },
     "mdast-util-to-markdown": {
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz",
@@ -4593,6 +4705,15 @@
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-0.3.3.tgz",
       "integrity": "sha512-0zvM5iSLKrc/NQl84pZSjGo66aTGd57C1idmlWmE87lkMcXrTxg1uXa/nXomxJytoje9trP0NDLvw4bZ/Z/XCQ==",
       "requires": {
+        "micromark": "~2.11.0"
+      }
+    },
+    "micromark-extension-math": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-0.1.2.tgz",
+      "integrity": "sha512-ZJXsT2eVPM8VTmcw0CPSDeyonOn9SziGK3Z+nkf9Vb6xMPeU+4JMEnO6vzDL10562Favw8Vste74f54rxJ/i6Q==",
+      "requires": {
+        "katex": "^0.12.0",
         "micromark": "~2.11.0"
       }
     },
@@ -4846,6 +4967,15 @@
       "requires": {
         "mdast-util-gfm": "^0.1.0",
         "micromark-extension-gfm": "^0.3.0"
+      }
+    },
+    "remark-math": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-4.0.0.tgz",
+      "integrity": "sha512-lH7SoQenXtQrvL0bm+mjZbvOk//YWNuyR+MxV18Qyv8rgFmMEGNuB0TSCQDkoDaiJ40FCnG8lxErc/zhcedYbw==",
+      "requires": {
+        "mdast-util-math": "^0.1.0",
+        "micromark-extension-math": "^0.1.0"
       }
     },
     "remark-parse": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "repository": "https://github.com/infinitaslearning/notionater",
   "dependencies": {
     "@notionhq/client": "^0.4.4",
-    "@tryfabric/martian": "github:cliftonc/martian#better-images",
+    "@tryfabric/martian": "github:tryfabric/martian",
     "await-spawn": "^4.0.2",
     "cli-progress": "^3.9.1",
     "commander": "^8.3.0",


### PR DESCRIPTION
Main improvements:
- Markdown Table conversion to Notion
- Markdown Math conversion to Notion
  - from MD inline syntax `$ a \cdot b = c$`
  - from MD multiline syntax
    ```
    $$
    \texttt{my_equation} = d \cdot e
    $$
    ```
